### PR TITLE
Fix Matrix field manipulation contexts to support localization

### DIFF
--- a/pimpmymatrix/services/PimpMyMatrixService.php
+++ b/pimpmymatrix/services/PimpMyMatrixService.php
@@ -162,9 +162,9 @@ class PimpMyMatrixService extends BaseApplicationComponent
       }
 
       // Global sets
-      else if ( count($segments) == 2 && $segments[0] == 'globals' )
+      else if ( count($segments) >= 2 && $segments[0] == 'globals' )
       {
-        $set = craft()->globals->getSetByHandle($segments[1]);
+        $set = craft()->globals->getSetByHandle(end($segments));
         if ($set)
         {
           $context = 'globalset:'.$set->id;

--- a/pimpmymatrix/services/PimpMyMatrixService.php
+++ b/pimpmymatrix/services/PimpMyMatrixService.php
@@ -128,7 +128,7 @@ class PimpMyMatrixService extends BaseApplicationComponent
       $context = 'global';
 
       // Entry types
-      if ( count($segments) == 3 && $segments[0] == 'entries' )
+      if ( count($segments) >= 3 && $segments[0] == 'entries' )
       {
         if ($segments[2] == 'new')
         {

--- a/pimpmymatrix/services/PimpMyMatrixService.php
+++ b/pimpmymatrix/services/PimpMyMatrixService.php
@@ -147,8 +147,7 @@ class PimpMyMatrixService extends BaseApplicationComponent
           }
         }
 
-        $cont
-        ext = 'entrytype:'.$entryType->id;
+        $context = 'entrytype:'.$entryType->id;
       }
 
       // Category groups

--- a/pimpmymatrix/services/PimpMyMatrixService.php
+++ b/pimpmymatrix/services/PimpMyMatrixService.php
@@ -130,7 +130,6 @@ class PimpMyMatrixService extends BaseApplicationComponent
       // Entry types
       if ( count($segments) == 3 && $segments[0] == 'entries' )
       {
-
         if ($segments[2] == 'new')
         {
           $section = craft()->sections->getSectionByHandle($segments[1]);
@@ -149,6 +148,7 @@ class PimpMyMatrixService extends BaseApplicationComponent
         }
 
         $cont
+        ext = 'entrytype:'.$entryType->id;
       }
 
       // Category groups

--- a/pimpmymatrix/services/PimpMyMatrixService.php
+++ b/pimpmymatrix/services/PimpMyMatrixService.php
@@ -148,18 +148,19 @@ class PimpMyMatrixService extends BaseApplicationComponent
           }
         }
 
-        $context = 'entrytype:'.$entryType->id;
+        $cont
+      }
 
-      }
       // Category groups
-        else if ( count($segments) == 3 && $segments[0] == 'categories' )
+      else if ( count($segments) == 3 && $segments[0] == 'categories' )
+      {
+        $group = craft()->categories->getGroupByHandle($segments[1]);
+        if ($group)
         {
-          $group = craft()->categories->getGroupByHandle($segments[1]);
-          if ($group)
-          {
-            $context = 'categorygroup:'.$group->id;
-          }
+          $context = 'categorygroup:'.$group->id;
+        }
       }
+
       // Global sets
       else if ( count($segments) == 2 && $segments[0] == 'globals' )
       {
@@ -169,6 +170,7 @@ class PimpMyMatrixService extends BaseApplicationComponent
           $context = 'globalset:'.$set->id;
         }
       }
+
       // Users
       else if ( (count($segments) == 1 && $segments[0] == 'myaccount') || (count($segments) == 2 && $segments[0] == 'users') )
       {


### PR DESCRIPTION
Craft Entries and Globals can be localized, which changes the URL segment patterns used to display these pages.

**Entries**
from:
cp/entries/section/slug
to:
cp/entries/section/slug/locale

**Globals**
from:
cp/globals/set
to:
cp/globals/locale/set

This PR updates the conditions used to determine display contexts and load the PMP Field Manipulator.
